### PR TITLE
Feature utility url creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-
+/launchConfigurations
+/node_modules

--- a/app/chain/alchemy/alchemy.resource.js
+++ b/app/chain/alchemy/alchemy.resource.js
@@ -9,6 +9,7 @@ var Promise = require('bluebird');
 var config = require('config');
 var responseHandler = require('../../handler/response.handler');
 var errorHandler = require('../../handler/error.handler');
+var utils  = require('../../utility/utils');
 
 var url = config.RESOURCE_ALCHEMY_URL;
 var apikey = config.RESOURCE_ALCHEMY_API_KEY;
@@ -16,15 +17,22 @@ var apikey = config.RESOURCE_ALCHEMY_API_KEY;
 exports.get = function() {
     var options = {
         resolveWithFullResponse: true,
-        uri: url + '?' + 'apiKey=' + apikey + '&outputMode=json' + '&url=' + url,
+        uri : url,
+        //uri: url + '?' + 'apiKey=' + apikey + '&outputMode=json' + '&url=' + url,
         method: 'GET',
         json: true,
         gzip: true
     };
-    
-    
-    return request(options)
+
+    var params = {
+        "url": "https://en.wikipedia.org/wiki/Steve_Jobs",
+        "apikey": apikey,
+        "outputMode": "json"
+    };
+
+    return utils.setUrlParamsForOptions(params, options)
+        .then(request)
         .then(responseHandler.parseGet)
         .catch(errorHandler.throwResourceError);
-    
+
 };

--- a/app/utility/utils.js
+++ b/app/utility/utils.js
@@ -1,0 +1,21 @@
+/*eslint-env node */
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var Promise = require('bluebird');
+
+/**
+ * options: the options object needed for request-promise
+ * params: the parameters to be passed as url params
+ */
+exports.setUrlParamsForOptions = function(params, options) {
+    return new Promise.reduce(Object.keys(params), function(acc, param) {
+        return acc + param + '=' + params[param] + '&';
+    }, options.uri + '?')
+    .then(function(res) {
+        options.uri = res;
+        return options;
+    })
+};

--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
-    "RESOURCE_URL_WATSON": "http://some/url.com",    
+    "RESOURCE_URL_WATSON": "http://some/url.com",
     "RESOURCE_ALCHEMY_API_KEY": "9da318e13054c45454b95f3d9db450041f69a507",
-    "RESOURCE_ALCHEMY_URL": "",
+    "RESOURCE_ALCHEMY_URL": "http://gateway-a.watsonplatform.net/calls/url/URLGetRankedNamedEntities",
     "RESOURCE_SCOPUS_API_KEY": "0fa3758c6732da42117e1983ff7c4e10",
     "RESOURCE_SCOPUS_SEARCH_URL": "http://api.elsevier.com/content/search/scopus",
     "RESOURCE_SCOPUS_SEARCH_AUTHOR_URL": "http://api.elsevier.com/content/search/author",


### PR DESCRIPTION
Added a utility function for creating urls with parameters; for request-promise options.

function setUrlParamsForOptions(params, options): 
 returns: options with modified url
 prarams: parameters in an object, ex {url: "my/url/", id: "myId"}
 options: the request-promise options object; with set url
